### PR TITLE
Fix url rerouting

### DIFF
--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,6 +1,7 @@
+import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async () => {
-  throw redirect(307, '/en');
+  throw redirect(307, `${base}/en`);
 }; 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -25,7 +25,7 @@ const config = {
 		adapter: adapter({
 			pages: 'build',
 			assets: 'build',
-			fallback: 'index.html',
+			fallback: '404.html', // important for redirecting if you directly access pages with lang in the url.  
 			precompress: false,
 			strict: false
 		}),


### PR DESCRIPTION
Adding 404.html will automatically redirect. Otherwise accessing pages like .app/en/help will fail. Something about github pages being static and lang rerouting being dynamic. But this should fix it.